### PR TITLE
Updating Lab section so website repo won't end up at the top every time I post something.

### DIFF
--- a/lab.html
+++ b/lab.html
@@ -61,6 +61,8 @@
     });
 
     repos.forEach(repo => {
+      if (repo.name === "freshcake-site-build") return;
+
       unified.push({
         title: repo.name,
         description: repo.description || "No description provided.",

--- a/lab.html
+++ b/lab.html
@@ -61,7 +61,7 @@
     });
 
     repos.forEach(repo => {
-      if (repo.name === "freshcake-site-build") return;
+      if (repo.name === "freshcake-site-build") return; // Keep repo from floating to top on every update
 
       unified.push({
         title: repo.name,


### PR DESCRIPTION
Based on how the Lab pulls in my GitHub repos. anytime I published a blog post. the website build always appeared first.